### PR TITLE
Wave Generation APIs

### DIFF
--- a/audioplayer/audio.cpp
+++ b/audioplayer/audio.cpp
@@ -2,55 +2,88 @@
 
 #include "audioplayer.hpp"
 
-namespace Audio {
-    AudioPlayer* audioPlayer;
+namespace Audio
+{
+    AudioPlayer *audioPlayer;
 
-    void initPlayer(int debug) {
+    void initPlayer(int debug)
+    {
         audioPlayer = new AudioPlayer(static_cast<bool>(debug));
     }
 
-    void setDevice(int deviceIndex) {
+    void setDevice(int deviceIndex)
+    {
         audioPlayer->setDevice(deviceIndex);
     }
 
-    void loadPlayer(const char* fileLocation) {
+    void loadPlayer(const char *fileLocation)
+    {
         audioPlayer->load(fileLocation);
     }
 
-    void playPlayer() {
+    void playPlayer()
+    {
         audioPlayer->play();
     }
 
-    void pausePlayer() {
+    void pausePlayer()
+    {
         audioPlayer->pause();
     }
 
-    void stopPlayer() {
+    void stopPlayer()
+    {
         audioPlayer->stop();
     }
 
-    int getDuration() {
+    int getDuration()
+    {
         return audioPlayer->getDuration();
     }
 
-    int getPosition() {
+    int getPosition()
+    {
         return audioPlayer->getPosition();
     }
 
-    void setPosition(int timeMilliseconds) {
+    void setPosition(int timeMilliseconds)
+    {
         audioPlayer->setPosition(timeMilliseconds);
     }
 
-    void setVolume(double volume) {
+    void setVolume(double volume)
+    {
         audioPlayer->setVolume(volume);
     }
 
-    float getVolume() {
+    void setWaveFrequency(double frequency)
+    {
+        audioPlayer->setWaveFrequency(frequency);
+    }
+
+    void setWaveAmplitude(double amplitude)
+    {
+        audioPlayer->setWaveAmplitude(amplitude);
+    }
+
+    void setWaveSampleRate(int sampleRate)
+    {
+        audioPlayer->setWaveSampleRate(sampleRate);
+    }
+
+    void loadSine(double amplitude, double frequency, int waveType)
+    {
+        audioPlayer->loadSine(amplitude, frequency, waveType);
+    }
+
+    float getVolume()
+    {
         return audioPlayer->getVolume();
     }
-}
+} // namespace Audio
 
-int main(int argc, const char** argv) {
+int main(int argc, const char **argv)
+{
     AudioPlayer audioPlayer(true);
     audioPlayer.load(argv[2]);
     audioPlayer.play();

--- a/audioplayer/audio.cpp
+++ b/audioplayer/audio.cpp
@@ -71,9 +71,9 @@ namespace Audio
         audioPlayer->setWaveSampleRate(sampleRate);
     }
 
-    void loadSine(double amplitude, double frequency, int waveType)
+    void loadWave(double amplitude, double frequency, int waveType)
     {
-        audioPlayer->loadSine(amplitude, frequency, waveType);
+        audioPlayer->loadWave(amplitude, frequency, waveType);
     }
 
     float getVolume()

--- a/audioplayer/audioplayer.hpp
+++ b/audioplayer/audioplayer.hpp
@@ -227,7 +227,7 @@ public:
         ma_waveform_set_sample_rate(&this->sineWave, waveSampleRate);
     }
 
-    void loadSine(double amplitude, double frequency, int waveType)
+    void loadWave(double amplitude, double frequency, int waveType)
     {
         // 0 = sine
         // 1 = square

--- a/audioplayer/audioplayer.hpp
+++ b/audioplayer/audioplayer.hpp
@@ -5,21 +5,32 @@
 #include <thread>
 #include <iostream>
 
-
-void dataCallback(ma_device* pDevice, void* pOutput, const void* pInput, ma_uint32 frameCount)
+void dataCallback(ma_device *pDevice, void *pOutput, const void *pInput, ma_uint32 frameCount)
 {
-    ma_decoder* pDecoder = (ma_decoder*)pDevice->pUserData;
-    if (pDecoder == NULL) {
+    ma_decoder *pDecoder = (ma_decoder *)pDevice->pUserData;
+    if (pDecoder == NULL)
+    {
         return;
     }
     ma_decoder_read_pcm_frames(pDecoder, pOutput, frameCount);
     (void)pInput;
 }
 
+void dataCallbackWave(ma_device *pDevice, void *pOutput, const void *pInput, ma_uint32 frameCount)
+{
+    ma_waveform *pSineWave;
 
-class AudioPlayerInternal {
-    public:
+    pSineWave = (ma_waveform *)pDevice->pUserData;
+    MA_ASSERT(pSineWave != NULL);
 
+    ma_waveform_read_pcm_frames(pSineWave, pOutput, frameCount);
+
+    (void)pInput; /* Unused. */
+}
+
+class AudioPlayerInternal
+{
+public:
     ma_format sampleFormat = ma_format_f32;
     int channelCount = 2;
     int sampleRate = 48000;
@@ -28,136 +39,230 @@ class AudioPlayerInternal {
     ma_device device;
     ma_device_config deviceConfig;
     ma_decoder decoder;
-    ma_device_info* pPlaybackDeviceInfos;
+    ma_device_info *pPlaybackDeviceInfos;
     ma_uint32 playbackDeviceCount;
-    
+    ma_waveform_config sineWaveConfig;
+    ma_waveform sineWave;
+
     bool debug;
     int audioDurationMilliseconds;
 
-    void showDevices() {
+    void showDevices()
+    {
         ma_context context;
-        if (ma_context_init(NULL, 0, NULL, &context) != MA_SUCCESS) {
+        if (ma_context_init(NULL, 0, NULL, &context) != MA_SUCCESS)
+        {
         }
-        ma_device_info* pCaptureDeviceInfos;
+        ma_device_info *pCaptureDeviceInfos;
         ma_uint32 captureDeviceCount;
-        if (ma_context_get_devices(&context, &this->pPlaybackDeviceInfos, &this->playbackDeviceCount, &pCaptureDeviceInfos, &captureDeviceCount) != MA_SUCCESS) {
+        if (ma_context_get_devices(&context, &this->pPlaybackDeviceInfos, &this->playbackDeviceCount, &pCaptureDeviceInfos, &captureDeviceCount) != MA_SUCCESS)
+        {
         }
-        for (ma_uint32 index = 0; index < this->playbackDeviceCount; index += 1) {
+        for (ma_uint32 index = 0; index < this->playbackDeviceCount; index += 1)
+        {
             std::cout << index << " - " << this->pPlaybackDeviceInfos[index].name << std::endl;
         }
     }
 
-    void loadFile(const char* file) {
+    void loadFile(const char *file)
+    {
         ma_decoder_config config = ma_decoder_config_init(this->sampleFormat, this->channelCount, this->sampleRate);
         ma_decoder_init_file(file, &config, &this->decoder);
-        
+
         ma_uint64 audioDurationFrames = ma_decoder_get_length_in_pcm_frames(&this->decoder);
         this->audioDurationMilliseconds = ma_calculate_buffer_size_in_milliseconds_from_frames(static_cast<int>(audioDurationFrames), this->sampleRate);
     }
 
-    void initDevice() {
+    void initDevice()
+    {
         ma_device_id selectedDeviceId = this->pPlaybackDeviceInfos[this->deviceIndex].id;
         this->deviceConfig = ma_device_config_init(ma_device_type_playback);
         this->deviceConfig.playback.pDeviceID = &selectedDeviceId;
-        this->deviceConfig.playback.format   = this->decoder.outputFormat;
+        this->deviceConfig.playback.format = this->decoder.outputFormat;
         this->deviceConfig.playback.channels = this->decoder.outputChannels;
-        this->deviceConfig.sampleRate        = this->decoder.outputSampleRate;
-        this->deviceConfig.dataCallback      = dataCallback;
-        this->deviceConfig.pUserData         = &this->decoder;
+        this->deviceConfig.sampleRate = this->decoder.outputSampleRate;
+        this->deviceConfig.dataCallback = dataCallback;
+        this->deviceConfig.pUserData = &this->decoder;
         ma_device_init(NULL, &this->deviceConfig, &this->device);
-
-        if (this->debug) {
+        if (this->debug)
+        {
             std::cout << "Channel Count: " << this->decoder.outputChannels << std::endl;
             std::cout << "Sample Rate  : " << this->decoder.outputSampleRate << std::endl;
         }
     }
+
+    void initDeviceWave()
+    {
+        
+        ma_device_id selectedDeviceId = this->pPlaybackDeviceInfos[this->deviceIndex].id;
+        this->deviceConfig = ma_device_config_init(ma_device_type_playback);
+        this->deviceConfig.playback.pDeviceID = &selectedDeviceId;
+        this->deviceConfig.playback.format = this->sampleFormat;
+        this->deviceConfig.playback.channels = this->channelCount;
+        this->deviceConfig.sampleRate = this->sampleRate;
+        this->deviceConfig.dataCallback = dataCallbackWave;
+        this->deviceConfig.pUserData = &this->sineWave;
+        ma_device_init(NULL, &this->deviceConfig, &this->device);
+
+        if (this->debug)
+        {
+            std::cout << "Channel Count: " << this->channelCount << std::endl;
+            std::cout << "Sample Rate  : " << this->sampleRate << std::endl;
+        }
+    }
 };
 
-
-class AudioPlayer: public AudioPlayerInternal {
-    public:
-
-    AudioPlayer(bool debug = false) {
+class AudioPlayer : public AudioPlayerInternal
+{
+public:
+    AudioPlayer(bool debug = false)
+    {
         this->debug = debug;
         this->showDevices();
     }
 
-    void setDevice(int index) {
+    void setDevice(int index)
+    {
         this->deviceIndex = index;
-        if (this->debug) {
+        if (this->debug)
+        {
             std::cout << "Selected Device: " << this->deviceIndex << " - " << this->pPlaybackDeviceInfos[deviceIndex].name << std::endl;
         }
     }
 
-    void load(const char* file) {
+    void load(const char *file)
+    {
         this->loadFile(file);
         this->initDevice();
-        if (this->debug) {
+        if (this->debug)
+        {
             std::cout << "Loaded File: " << file << std::endl;
         }
     }
 
-    void play(bool await = false) {
+    void play(bool await = false)
+    {
         ma_device_start(&this->device);
 
-        if (this->debug) {
+        if (this->debug)
+        {
             std::cout << std::boolalpha;
             std::cout << "Started Playback. await = " << await << std::endl;
         }
-        if (await) std::this_thread::sleep_for(std::chrono::milliseconds(this->getDuration()));
+        if (await)
+            std::this_thread::sleep_for(std::chrono::milliseconds(this->getDuration()));
     }
 
-    void pause() {
+    void pause()
+    {
         ma_device_stop(&this->device);
-        if (this->debug) {
+        if (this->debug)
+        {
             std::cout << "Paused Playback." << std::endl;
         }
     }
 
-    void stop() {
+    void stop()
+    {
         ma_device_stop(&this->device);
         ma_decoder_uninit(&this->decoder);
-        if (this->debug) {
+        if (this->debug)
+        {
             std::cout << "Stopped Playback." << std::endl;
         }
     }
 
-    int getDuration() {
-        if (this->debug) {
+    int getDuration()
+    {
+        if (this->debug)
+        {
             std::cout << "Audio Duration: " << this->audioDurationMilliseconds << " ms" << std::endl;
         }
         return this->audioDurationMilliseconds;
     }
 
-    void setPosition(int timeMilliseconds) {
+    void setPosition(int timeMilliseconds)
+    {
         int timeFrames = ma_calculate_buffer_size_in_frames_from_milliseconds(timeMilliseconds, this->sampleRate);
         ma_decoder_seek_to_pcm_frame(&decoder, timeFrames);
-        if (this->debug) {
+        if (this->debug)
+        {
             std::cout << "Set Position: " << timeMilliseconds << " ms" << std::endl;
         }
     }
 
-    int getPosition() {
+    int getPosition()
+    {
         ma_uint64 positionFrames;
         ma_decoder_get_cursor_in_pcm_frames(&this->decoder, &positionFrames);
         int positionMilliseconds = ma_calculate_buffer_size_in_milliseconds_from_frames(static_cast<int>(positionFrames), this->sampleRate);
-        if (this->debug) {
+        if (this->debug)
+        {
             std::cout << "Current Position: " << positionMilliseconds << " ms" << std::endl;
         }
         return positionMilliseconds;
     }
 
-    void setVolume(double volume) {
+    void setVolume(double volume)
+    {
         ma_device_set_master_volume(&this->device, static_cast<float>(volume));
-        if (this->debug) {
+        if (this->debug)
+        {
             std::cout << "Set Volume: " << volume << std::endl;
         }
     }
 
-    float getVolume() {
+    void setWaveFrequency(double frequency)
+    {
+        ma_waveform_set_frequency(&this->sineWave, frequency);
+    }
+
+    void setWaveAmplitude(double amplitude)
+    {
+        ma_waveform_set_amplitude(&this->sineWave, amplitude);
+    }
+
+    void setWaveSampleRate(int waveSampleRate)
+    {
+        ma_waveform_set_sample_rate(&this->sineWave, waveSampleRate);
+    }
+
+    void loadSine(double amplitude, double frequency, int waveType)
+    {
+        // 0 = sine
+        // 1 = square
+        // 2 = triangle
+        // 3 = sawtooth
+        ma_waveform_type maWaveType = ma_waveform_type_sine;
+        switch (waveType)
+        {
+        case 0:
+            maWaveType = ma_waveform_type_sine;
+            break;
+        case 1:
+            maWaveType = ma_waveform_type_square;
+            break;
+        case 2:
+            maWaveType = ma_waveform_type_triangle;
+            break;
+        case 3:
+            maWaveType = ma_waveform_type_sawtooth;
+            break;
+        }
+
+        this->sineWaveConfig =
+        ma_waveform_config_init(this->sampleFormat, this->channelCount,
+                                this->sampleRate, maWaveType, amplitude, frequency);
+        ma_waveform_init(&this->sineWaveConfig, &this->sineWave);
+        this->initDeviceWave();
+    }
+
+    float getVolume()
+    {
         float volume;
         ma_device_get_master_volume(&this->device, &volume);
-        if (this->debug) {
+        if (this->debug)
+        {
             std::cout << "Current Volume: " << volume << std::endl;
         }
         return volume;

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -51,6 +51,20 @@ class PlayerState extends State<Player> {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
+            Row(mainAxisSize: MainAxisSize.min, children: [
+              Text("Load Wave"),
+              IconButton(
+                color: Colors.blue,
+                icon: Icon(
+                  Icons.check,
+                  size: 28,
+                ),
+                onPressed: () async {
+                  audioPlayer.setDevice(deviceIndex: 2);
+                  audioPlayer.loadSine(0.2, 400, 0);
+                },
+              ),
+            ]),
             Padding(
               padding: EdgeInsets.all(32),
               child: Row(
@@ -81,7 +95,8 @@ class PlayerState extends State<Player> {
                     tooltip: 'Load Audio',
                     onPressed: () async {
                       /// Setting playback device manually (if you have more than one playback device).
-                      audioPlayer.setDevice(deviceIndex: 0);
+                      audioPlayer.setDevice(deviceIndex: 2);
+
                       /// Loading an audio file into the player.
                       bool result =
                           await audioPlayer.load(this._textFieldValue);
@@ -100,7 +115,7 @@ class PlayerState extends State<Player> {
               ),
             ),
             Padding(
-                padding: EdgeInsets.all(64),
+                padding: EdgeInsets.all(24),
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
@@ -116,6 +131,63 @@ class PlayerState extends State<Player> {
                           this.setState(() {
                             /// Changing player volume.
                             this.audioPlayer.setVolume(value);
+                          });
+                        }),
+                  ],
+                )),
+            Padding(
+                padding: EdgeInsets.all(24), child: Text("Wave Settings: ")),
+            Padding(
+                padding: EdgeInsets.all(24),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(
+                      Icons.multiline_chart,
+                      size: 36,
+                      color: Colors.blue,
+                    ),
+                    Slider(
+                        divisions: 10,
+                        value: audioPlayer.waveAmplitude,
+                        min: 0.0,
+                        max: 1,
+                        onChanged: (value) {
+                          this.setState(() {
+                            /// Changing player volume.
+                            this.audioPlayer.setWaveAmplitude(value);
+                          });
+                        }),
+                    Icon(
+                      Icons.radio,
+                      size: 36,
+                      color: Colors.blue,
+                    ),
+                    Slider(
+                        divisions: 100,
+                        value: audioPlayer.waveFrequency,
+                        min: 0,
+                        max: 1000,
+                        onChanged: (value) {
+                          this.setState(() {
+                            /// Changing player volume.
+                            this.audioPlayer.setWaveFrequency(value);
+                          });
+                        }),
+                    Icon(
+                      Icons.timelapse,
+                      size: 36,
+                      color: Colors.blue,
+                    ),
+                    Slider(
+                        divisions: 1000,
+                        value: audioPlayer.waveSampleRate.toDouble(),
+                        min: 1000,
+                        max: 100000,
+                        onChanged: (value) {
+                          this.setState(() {
+                            /// Changing player volume.
+                            this.audioPlayer.setWaveSampleRate(value.toInt());
                           });
                         }),
                   ],

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -61,7 +61,7 @@ class PlayerState extends State<Player> {
                 ),
                 onPressed: () async {
                   audioPlayer.setDevice(deviceIndex: 2);
-                  audioPlayer.loadSine(0.2, 400, 0);
+                  audioPlayer.loadWave(0.2, 400, 0);
                 },
               ),
             ]),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,42 +7,42 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety"
+    version: "2.5.0-nullsafety.3"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety"
+    version: "2.1.0-nullsafety.3"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.2"
+    version: "1.1.0-nullsafety.5"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety"
+    version: "1.2.0-nullsafety.3"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.1.0-nullsafety.3"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.2"
+    version: "1.15.0-nullsafety.5"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -56,7 +56,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.2.0-nullsafety.3"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -80,21 +80,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety"
+    version: "0.12.10-nullsafety.3"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.2"
+    version: "1.3.0-nullsafety.6"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety"
+    version: "1.8.0-nullsafety.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -106,56 +106,56 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety"
+    version: "1.8.0-nullsafety.4"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety"
+    version: "1.10.0-nullsafety.6"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety"
+    version: "2.1.0-nullsafety.3"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.1.0-nullsafety.3"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety"
+    version: "1.2.0-nullsafety.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety"
+    version: "0.2.19-nullsafety.6"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.2"
+    version: "1.3.0-nullsafety.5"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.2"
+    version: "2.1.0-nullsafety.5"
 sdks:
-  dart: ">=2.10.0-0.0.dev <2.10.0"
+  dart: ">=2.12.0-0.0 <3.0.0"
   flutter: ">=1.20.0 <2.0.0"

--- a/lib/flutter_audio_desktop.dart
+++ b/lib/flutter_audio_desktop.dart
@@ -101,7 +101,7 @@ class AudioPlayer {
     return success;
   }
 
-  Future<bool> loadSine(
+  Future<bool> loadWave(
       double amplitude, double frequency, int waveType) async {
     this._setPlayerState(true, false, true, true);
     bool success;
@@ -111,7 +111,7 @@ class AudioPlayer {
       if (this._playerState[0]) {
         waveAmplitude = amplitude;
         waveFrequency = frequency;
-        await _channel.invokeMethod('loadSine', {
+        await _channel.invokeMethod('loadWave', {
           'amplitude': amplitude,
           'frequency': frequency,
           'waveType': waveType

--- a/lib/flutter_audio_desktop.dart
+++ b/lib/flutter_audio_desktop.dart
@@ -114,7 +114,7 @@ class AudioPlayer {
         await _channel.invokeMethod('loadWave', {
           'amplitude': amplitude,
           'frequency': frequency,
-          'waveType': waveType
+          'wave_type': waveType
         });
         success = true;
       } else {

--- a/lib/flutter_audio_desktop.dart
+++ b/lib/flutter_audio_desktop.dart
@@ -14,6 +14,9 @@ class AudioPlayer {
   bool isPaused = false;
   bool isStopped = true;
   double volume = 1.0;
+  double waveAmplitude = 0;
+  double waveFrequency = 0;
+  int waveSampleRate = 44800;
   List<bool> _playerState = [false, false, false, true];
 
   /// ## Starting Audio Service
@@ -34,11 +37,12 @@ class AudioPlayer {
   /// ## Changing Playback Device
   ///
   ///     await audioPlayer.setDevice(deviceIndex: 0);
-  /// 
+  ///
   /// NOTE: This method must be called before [load] method.
-  /// 
+  ///
   /// This method might be useful, if your device has more than one available playback devices.
-  void setDevice({int deviceIndex = 0}) => _channel.invokeMethod('setDevice', deviceIndex);
+  void setDevice({int deviceIndex = 0}) =>
+      _channel.invokeMethod('setDevice', deviceIndex);
 
   /// ## Loading Audio File
   ///
@@ -89,6 +93,29 @@ class AudioPlayer {
       if (this._playerState[0]) {
         this._setPlayerState(true, true, false, false);
         await _channel.invokeMethod('play');
+        success = true;
+      } else {
+        success = false;
+      }
+    }
+    return success;
+  }
+
+  Future<bool> loadSine(
+      double amplitude, double frequency, int waveType) async {
+    this._setPlayerState(true, false, true, true);
+    bool success;
+    if (this._playerState[1]) {
+      success = false;
+    } else {
+      if (this._playerState[0]) {
+        waveAmplitude = amplitude;
+        waveFrequency = frequency;
+        await _channel.invokeMethod('loadSine', {
+          'amplitude': amplitude,
+          'frequency': frequency,
+          'waveType': waveType
+        });
         success = true;
       } else {
         success = false;
@@ -204,6 +231,21 @@ class AudioPlayer {
   void setVolume(double volume) {
     _channel.invokeMethod('setVolume', volume);
     this.volume = volume;
+  }
+
+  void setWaveAmplitude(double amplitude) {
+    _channel.invokeMethod('setWaveAmplitude', amplitude);
+    this.waveAmplitude = amplitude;
+  }
+
+  void setWaveFrequency(double frequency) {
+    _channel.invokeMethod('setWaveFrequency', frequency);
+    this.waveFrequency = frequency;
+  }
+
+  void setWaveSampleRate(int sampleRate) {
+    _channel.invokeMethod('setWaveSampleRate', sampleRate);
+    this.waveSampleRate = sampleRate;
   }
 
   void _setPlayerState(

--- a/linux/flutter_audio_desktop_plugin.cc
+++ b/linux/flutter_audio_desktop_plugin.cc
@@ -51,12 +51,12 @@ static void flutter_audio_desktop_plugin_handle_method_call(
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_null()));
   }
 
-  else if (strcmp(method, "loadSine") == 0)
+  else if (strcmp(method, "loadWave") == 0)
   {
     const float amplitude = fl_value_get_float(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("amplitude")));
     const float frequency = fl_value_get_float(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("frequency")));
     const int waveType = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("waveType")));
-    Audio::loadSine(amplitude, frequency, waveType);
+    Audio::loadWave(amplitude, frequency, waveType);
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_null()));
   }
 

--- a/linux/flutter_audio_desktop_plugin.cc
+++ b/linux/flutter_audio_desktop_plugin.cc
@@ -55,7 +55,7 @@ static void flutter_audio_desktop_plugin_handle_method_call(
   {
     const float amplitude = fl_value_get_float(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("amplitude")));
     const float frequency = fl_value_get_float(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("frequency")));
-    const int waveType = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("waveType")));
+    const int waveType = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("wave_type")));
     Audio::loadWave(amplitude, frequency, waveType);
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_null()));
   }

--- a/linux/flutter_audio_desktop_plugin.cc
+++ b/linux/flutter_audio_desktop_plugin.cc
@@ -1,31 +1,31 @@
 #include "../audioplayer/audio.cpp"
 
-
 #include "include/flutter_audio_desktop/flutter_audio_desktop_plugin.h"
 #include <flutter_linux/flutter_linux.h>
 #include <gtk/gtk.h>
 #include <sys/utsname.h>
 
-
-#define FLUTTER_AUDIO_DESKTOP_PLUGIN(obj) \
+#define FLUTTER_AUDIO_DESKTOP_PLUGIN(obj)                                     \
   (G_TYPE_CHECK_INSTANCE_CAST((obj), flutter_audio_desktop_plugin_get_type(), \
                               FlutterAudioDesktopPlugin))
 
-struct _FlutterAudioDesktopPlugin {
+struct _FlutterAudioDesktopPlugin
+{
   GObject parent_instance;
 };
 
 G_DEFINE_TYPE(FlutterAudioDesktopPlugin, flutter_audio_desktop_plugin, g_object_get_type())
 
 static void flutter_audio_desktop_plugin_handle_method_call(
-    FlutterAudioDesktopPlugin* self,
-    FlMethodCall* method_call) {
+    FlutterAudioDesktopPlugin *self,
+    FlMethodCall *method_call)
+{
   g_autoptr(FlMethodResponse) response = nullptr;
 
-  const gchar* method = fl_method_call_get_name(method_call);
+  const gchar *method = fl_method_call_get_name(method_call);
 
-
-  if (strcmp(method, "init") == 0) {
+  if (strcmp(method, "init") == 0)
+  {
     int debug = fl_value_get_int(fl_method_call_get_args(method_call));
 
     Audio::initPlayer(debug);
@@ -33,7 +33,8 @@ static void flutter_audio_desktop_plugin_handle_method_call(
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_null()));
   }
 
-  if (strcmp(method, "setDevice") == 0) {
+  if (strcmp(method, "setDevice") == 0)
+  {
     int deviceIndex = fl_value_get_int(fl_method_call_get_args(method_call));
 
     Audio::setDevice(deviceIndex);
@@ -41,33 +42,47 @@ static void flutter_audio_desktop_plugin_handle_method_call(
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_null()));
   }
 
-  else if (strcmp(method, "load") == 0) {
-    const gchar* fileName = fl_value_get_string(fl_method_call_get_args(method_call));
+  else if (strcmp(method, "load") == 0)
+  {
+    const gchar *fileName = fl_value_get_string(fl_method_call_get_args(method_call));
 
     Audio::loadPlayer(fileName);
 
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_null()));
   }
 
-  else if (strcmp(method, "play") == 0) {
+  else if (strcmp(method, "loadSine") == 0)
+  {
+    const float amplitude = fl_value_get_float(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("amplitude")));
+    const float frequency = fl_value_get_float(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("frequency")));
+    const int waveType = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("waveType")));
+    Audio::loadSine(amplitude, frequency, waveType);
+    response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_null()));
+  }
+
+  else if (strcmp(method, "play") == 0)
+  {
     Audio::playPlayer();
 
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_null()));
   }
-  
-  else if (strcmp(method, "pause") == 0) {
+
+  else if (strcmp(method, "pause") == 0)
+  {
     Audio::pausePlayer();
 
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_null()));
   }
 
-  else if (strcmp(method, "stop") == 0) {
+  else if (strcmp(method, "stop") == 0)
+  {
     Audio::stopPlayer();
 
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_null()));
   }
 
-  else if (strcmp(method, "getDuration") == 0) {
+  else if (strcmp(method, "getDuration") == 0)
+  {
     int playerDuration = Audio::getDuration();
 
     g_autoptr(FlValue) playerDurationResponse = fl_value_new_int(playerDuration);
@@ -75,7 +90,8 @@ static void flutter_audio_desktop_plugin_handle_method_call(
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(playerDurationResponse));
   }
 
-  else if (strcmp(method, "getPosition") == 0) {
+  else if (strcmp(method, "getPosition") == 0)
+  {
     int playerPostion = Audio::getPosition();
 
     g_autoptr(FlValue) playerPostionResponse = fl_value_new_int(playerPostion);
@@ -83,7 +99,8 @@ static void flutter_audio_desktop_plugin_handle_method_call(
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(playerPostionResponse));
   }
 
-  else if (strcmp(method, "setPosition") == 0) {
+  else if (strcmp(method, "setPosition") == 0)
+  {
 
     int timeMilliseconds = fl_value_get_int(fl_method_call_get_args(method_call));
 
@@ -91,40 +108,69 @@ static void flutter_audio_desktop_plugin_handle_method_call(
 
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_null()));
   }
+    else if (strcmp(method, "setWaveAmplitude") == 0)
+  {
+    float amplitude = fl_value_get_float(fl_method_call_get_args(method_call));
 
-  else if (strcmp(method, "setVolume") == 0) {
+    Audio::setWaveAmplitude(amplitude);
+
+    response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_null()));
+  }
+    else if (strcmp(method, "setWaveFrequency") == 0)
+  {
+    float frequency = fl_value_get_float(fl_method_call_get_args(method_call));
+
+    Audio::setWaveFrequency(frequency);
+
+    response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_null()));
+  }
+    else if (strcmp(method, "setWaveSampleRate") == 0)
+  {
+    int sampleRate = fl_value_get_int(fl_method_call_get_args(method_call));
+
+    Audio::setWaveSampleRate(sampleRate);
+
+    response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_null()));
+  }
+
+  else if (strcmp(method, "setVolume") == 0)
+  {
     float volume = fl_value_get_float(fl_method_call_get_args(method_call));
 
     Audio::setVolume(volume);
 
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_null()));
   }
-  
-  
-  else {
+
+  else
+  {
     response = FL_METHOD_RESPONSE(fl_method_not_implemented_response_new());
   }
   fl_method_call_respond(method_call, response, nullptr);
 }
 
-static void flutter_audio_desktop_plugin_dispose(GObject* object) {
+static void flutter_audio_desktop_plugin_dispose(GObject *object)
+{
   G_OBJECT_CLASS(flutter_audio_desktop_plugin_parent_class)->dispose(object);
 }
 
-static void flutter_audio_desktop_plugin_class_init(FlutterAudioDesktopPluginClass* klass) {
+static void flutter_audio_desktop_plugin_class_init(FlutterAudioDesktopPluginClass *klass)
+{
   G_OBJECT_CLASS(klass)->dispose = flutter_audio_desktop_plugin_dispose;
 }
 
-static void flutter_audio_desktop_plugin_init(FlutterAudioDesktopPlugin* self) {}
+static void flutter_audio_desktop_plugin_init(FlutterAudioDesktopPlugin *self) {}
 
-static void method_call_cb(FlMethodChannel* channel, FlMethodCall* method_call,
-                           gpointer user_data) {
-  FlutterAudioDesktopPlugin* plugin = FLUTTER_AUDIO_DESKTOP_PLUGIN(user_data);
+static void method_call_cb(FlMethodChannel *channel, FlMethodCall *method_call,
+                           gpointer user_data)
+{
+  FlutterAudioDesktopPlugin *plugin = FLUTTER_AUDIO_DESKTOP_PLUGIN(user_data);
   flutter_audio_desktop_plugin_handle_method_call(plugin, method_call);
 }
 
-void flutter_audio_desktop_plugin_register_with_registrar(FlPluginRegistrar* registrar) {
-  FlutterAudioDesktopPlugin* plugin = FLUTTER_AUDIO_DESKTOP_PLUGIN(
+void flutter_audio_desktop_plugin_register_with_registrar(FlPluginRegistrar *registrar)
+{
+  FlutterAudioDesktopPlugin *plugin = FLUTTER_AUDIO_DESKTOP_PLUGIN(
       g_object_new(flutter_audio_desktop_plugin_get_type(), nullptr));
 
   g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();

--- a/windows/flutter_audio_desktop_plugin.cpp
+++ b/windows/flutter_audio_desktop_plugin.cpp
@@ -90,7 +90,7 @@ namespace
 
       result->Success(flutter::EncodableValue(nullptr));
     }
-    else if (method_call.method_name() == "loadSine")
+    else if (method_call.method_name() == "loadWave")
     {
       double amplitude = 0;
       double frequency = 0;
@@ -116,7 +116,7 @@ namespace
         frequency = std::get<int>(encodedWaveType->second);
       }
 
-      Audio::loadSine(amplitude, frequency, waveType);
+      Audio::loadWave(amplitude, frequency, waveType);
 
       result->Success(flutter::EncodableValue(nullptr));
     }

--- a/windows/flutter_audio_desktop_plugin.cpp
+++ b/windows/flutter_audio_desktop_plugin.cpp
@@ -113,7 +113,7 @@ namespace
       auto encodedWaveType = arguments->find(flutter::EncodableValue("wave_type"));
       if (encodedWaveType != arguments->end())
       {
-        frequency = std::get<int>(encodedWaveType->second);
+        waveType = std::get<int>(encodedWaveType->second);
       }
 
       Audio::loadWave(amplitude, frequency, waveType);


### PR DESCRIPTION
This PR adds the following on Windows and Linux:

Wave Types
0 = sine
1 = square
2 = triangle
3 = sawtooth

loadWave(amplitude, frequency, waveType)
setWaveAmplitude(amplitude)
setWaveFrequency(frequency)
setWaveSampleRate(sampleRate)

I edited the example to allow loading of a wave and a few controls. Happy to rework if you see something that could be improved with this implementation. I'll likely add the buffer API at some point as well.