### PR TITLE
Allow multiple audio players

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ dependencies:
 ## :triangular_ruler: Usage
 
 ```dart
-// Start AudioPlayer.
-var audioPlayer = new AudioPlayer();
+// Start AudioPlayer and provide int for id.
+var audioPlayer = new AudioPlayer(id: 0);
 
-// Load audio file.
+// Load audio file
 audioPlayer.load('/home/alexmercerind/music.mp3');
 
 // Start playing loaded audio file.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ dependencies:
 
 ```dart
 // Start AudioPlayer and provide int for id.
+// Note: You must provide new IDs to additional instances.
 var audioPlayer = new AudioPlayer(id: 0);
 
 // Load audio file
@@ -49,6 +50,19 @@ Timer(Duration(seconds: 10), () {
     audioPlayer.pause();
     print('Playback of audio stopped after 10 seconds.');
 }
+
+// Load wave
+audioPlayer.loadWave(amplitude, frequency, type)
+
+// Set frequency
+audioPlayer.setWaveFrequency(double frequency);
+
+// Set Amplitude
+audioPlayer.setWaveAmplitude(double amplitude);
+
+// Set Sample Rate
+audioPlayer.setWaveSampleRate(int sampleRate)
+
 ```
 
 You can see [this](https://github.com/alexmercerind/flutter_audio_desktop/blob/master/example/lib/main.dart) simple example app, if you are confused with the usage.

--- a/audioplayer/audio.cpp
+++ b/audioplayer/audio.cpp
@@ -4,80 +4,97 @@
 
 namespace Audio
 {
-    AudioPlayer *audioPlayer;
 
-    void initPlayer(int debug)
+    AudioPlayerManager* audioPlayerManager = new AudioPlayerManager();
+
+    void initPlayer(int id, int debug)
     {
-        audioPlayer = new AudioPlayer(static_cast<bool>(debug));
+
+        AudioPlayer* audioPlayer = new AudioPlayer(id, static_cast<bool>(debug));
+        audioPlayerManager->players.insert(audioPlayerManager->players.end(), audioPlayer);
     }
 
-    void setDevice(int deviceIndex)
+    void setDevice(int id, int deviceIndex)
     {
+        AudioPlayer* audioPlayer = audioPlayerManager->players.at(id);
         audioPlayer->setDevice(deviceIndex);
     }
 
-    void loadPlayer(const char *fileLocation)
+    void loadPlayer(int id, const char *fileLocation)
     {
+        auto audioPlayer = audioPlayerManager->players.at(id);
         audioPlayer->load(fileLocation);
     }
 
-    void playPlayer()
+    void playPlayer(int id)
     {
+       auto audioPlayer = audioPlayerManager->players.at(id);
         audioPlayer->play();
     }
 
-    void pausePlayer()
+    void pausePlayer(int id)
     {
+        auto audioPlayer = audioPlayerManager->players.at(id);
         audioPlayer->pause();
     }
 
-    void stopPlayer()
+    void stopPlayer(int id)
     {
+        auto audioPlayer = audioPlayerManager->players.at(id);
         audioPlayer->stop();
     }
 
-    int getDuration()
+    int getDuration(int id)
     {
+        auto audioPlayer = audioPlayerManager->players.at(id);
         return audioPlayer->getDuration();
     }
 
-    int getPosition()
+    int getPosition(int id)
     {
+        auto audioPlayer = audioPlayerManager->players.at(id);
         return audioPlayer->getPosition();
     }
 
-    void setPosition(int timeMilliseconds)
+    void setPosition(int id, int timeMilliseconds)
     {
+        auto audioPlayer = audioPlayerManager->players.at(id);
         audioPlayer->setPosition(timeMilliseconds);
     }
 
-    void setVolume(double volume)
+    void setVolume(int id, double volume)
     {
+        auto audioPlayer = audioPlayerManager->players.at(id);
         audioPlayer->setVolume(volume);
     }
 
-    void setWaveFrequency(double frequency)
+    void setWaveFrequency(int id, double frequency)
     {
+        auto audioPlayer = audioPlayerManager->players.at(id);
         audioPlayer->setWaveFrequency(frequency);
     }
 
-    void setWaveAmplitude(double amplitude)
+    void setWaveAmplitude(int id, double amplitude)
     {
+        auto audioPlayer = audioPlayerManager->players.at(id);
         audioPlayer->setWaveAmplitude(amplitude);
     }
 
-    void setWaveSampleRate(int sampleRate)
+    void setWaveSampleRate(int id, int sampleRate)
     {
+        auto audioPlayer = audioPlayerManager->players.at(id);
         audioPlayer->setWaveSampleRate(sampleRate);
     }
 
-    void loadWave(double amplitude, double frequency, int waveType)
+    void loadWave(int id, double amplitude, double frequency, int waveType)
     {
+        auto audioPlayer = audioPlayerManager->players.at(id);
         audioPlayer->loadWave(amplitude, frequency, waveType);
     }
 
-    float getVolume()
+    float getVolume(int id)
     {
+        auto audioPlayer = audioPlayerManager->players.at(id);
         return audioPlayer->getVolume();
     }
 } // namespace Audio

--- a/audioplayer/audio.cpp
+++ b/audioplayer/audio.cpp
@@ -5,18 +5,17 @@
 namespace Audio
 {
 
-    AudioPlayerManager* audioPlayerManager = new AudioPlayerManager();
+    AudioPlayerManager *audioPlayerManager = new AudioPlayerManager();
 
     void initPlayer(int id, int debug)
     {
-
-        AudioPlayer* audioPlayer = new AudioPlayer(id, static_cast<bool>(debug));
+        AudioPlayer *audioPlayer = new AudioPlayer(id, static_cast<bool>(debug));
         audioPlayerManager->players.insert(audioPlayerManager->players.end(), audioPlayer);
     }
 
     void setDevice(int id, int deviceIndex)
     {
-        AudioPlayer* audioPlayer = audioPlayerManager->players.at(id);
+        AudioPlayer *audioPlayer = audioPlayerManager->players.at(id);
         audioPlayer->setDevice(deviceIndex);
     }
 
@@ -28,7 +27,7 @@ namespace Audio
 
     void playPlayer(int id)
     {
-       auto audioPlayer = audioPlayerManager->players.at(id);
+        auto audioPlayer = audioPlayerManager->players.at(id);
         audioPlayer->play();
     }
 

--- a/audioplayer/audioplayer.hpp
+++ b/audioplayer/audioplayer.hpp
@@ -4,6 +4,7 @@
 #include "miniaudio.h"
 #include <thread>
 #include <iostream>
+#include <vector>
 
 void dataCallback(ma_device *pDevice, void *pOutput, const void *pInput, ma_uint32 frameCount)
 {
@@ -45,6 +46,7 @@ public:
     ma_waveform sineWave;
 
     bool debug;
+    int id;
     int audioDurationMilliseconds;
 
     void showDevices()
@@ -93,7 +95,7 @@ public:
 
     void initDeviceWave()
     {
-        
+
         ma_device_id selectedDeviceId = this->pPlaybackDeviceInfos[this->deviceIndex].id;
         this->deviceConfig = ma_device_config_init(ma_device_type_playback);
         this->deviceConfig.playback.pDeviceID = &selectedDeviceId;
@@ -115,9 +117,10 @@ public:
 class AudioPlayer : public AudioPlayerInternal
 {
 public:
-    AudioPlayer(bool debug = false)
+    AudioPlayer(int id = 1, bool debug = false)
     {
         this->debug = debug;
+        this->id = id;
         this->showDevices();
     }
 
@@ -251,8 +254,8 @@ public:
         }
 
         this->sineWaveConfig =
-        ma_waveform_config_init(this->sampleFormat, this->channelCount,
-                                this->sampleRate, maWaveType, amplitude, frequency);
+            ma_waveform_config_init(this->sampleFormat, this->channelCount,
+                                    this->sampleRate, maWaveType, amplitude, frequency);
         ma_waveform_init(&this->sineWaveConfig, &this->sineWave);
         this->initDeviceWave();
     }
@@ -267,4 +270,9 @@ public:
         }
         return volume;
     }
+};
+
+struct AudioPlayerManager
+{
+    std::vector <AudioPlayer*> players;
 };

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -9,6 +9,7 @@ class Player extends StatefulWidget {
 class PlayerState extends State<Player> {
   /// Simple player implementation. Setting debug: true for extra logging.
   AudioPlayer audioPlayer;
+  AudioPlayer audioPlayer2;
 
   GlobalKey<ScaffoldState> _scaffoldKey = new GlobalKey<ScaffoldState>();
   String _textFieldValue = '';
@@ -16,7 +17,8 @@ class PlayerState extends State<Player> {
   @override
   void initState() {
     super.initState();
-    this.audioPlayer = new AudioPlayer(debug: true);
+    this.audioPlayer = new AudioPlayer(id: 0, debug: true);
+    this.audioPlayer2 = new AudioPlayer(id: 1, debug: true);
   }
 
   Widget build(BuildContext context) {
@@ -35,9 +37,11 @@ class PlayerState extends State<Player> {
             if (audioPlayer.isPaused) {
               /// Playing loaded audio file.
               this.audioPlayer.play();
+              this.audioPlayer2.play();
             } else if (audioPlayer.isPlaying) {
               /// Pausing playback of loaded audio file.
               this.audioPlayer.pause();
+              this.audioPlayer2.pause();
             }
           }
         },
@@ -61,7 +65,10 @@ class PlayerState extends State<Player> {
                 ),
                 onPressed: () async {
                   audioPlayer.setDevice(deviceIndex: 2);
+                  audioPlayer2.setDevice(deviceIndex: 2);
+
                   audioPlayer.loadWave(0.2, 400, 0);
+                  audioPlayer2.loadWave(0.2, 700, 0);
                 },
               ),
             ]),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -64,9 +64,8 @@ class PlayerState extends State<Player> {
                   size: 28,
                 ),
                 onPressed: () async {
-                  audioPlayer.setDevice(deviceIndex: 2);
-                  audioPlayer2.setDevice(deviceIndex: 2);
-
+                  audioPlayer.setDevice(deviceIndex: 0);
+                  audioPlayer2.setDevice(deviceIndex: 0);
                   audioPlayer.loadWave(0.2, 400, 0);
                   audioPlayer2.loadWave(0.2, 700, 0);
                 },

--- a/lib/flutter_audio_desktop.dart
+++ b/lib/flutter_audio_desktop.dart
@@ -14,9 +14,9 @@ class AudioPlayer {
   bool isPlaying = false;
   bool isPaused = false;
   bool isStopped = true;
-  double volume = 1.0;
-  double waveAmplitude = 0;
-  double waveFrequency = 0;
+  double volume = .5;
+  double waveAmplitude = 0.1;
+  double waveFrequency = 440;
   int waveSampleRate = 44800;
   List<bool> _playerState = [false, false, false, true];
 

--- a/lib/flutter_audio_desktop.dart
+++ b/lib/flutter_audio_desktop.dart
@@ -27,7 +27,7 @@ class AudioPlayer {
   ///  You can optionally pass `debug: true` for extra logging.
   ///
   ///     AudioPlayer audioPlayer = new AudioPlayer(debug: true);
-  AudioPlayer({this.debug = false, this.id = 1}) {
+  AudioPlayer({this.debug = false, this.id = 0}) {
     if (this.debug) {
       _channel.invokeMethod('init', {'id': id, 'debug': true});
     } else {
@@ -109,6 +109,11 @@ class AudioPlayer {
   ///
   ///  Returns `Future<false>`, if the wave was not loaded
   ///
+  /// Types:
+  /// 0 = sine
+  /// 1 = square
+  /// 2 = triangle
+  /// 3 = sawtooth
   /// Example of valid waves:
   ///
   /// 1) `loadWave(0.2, 200, 0)`

--- a/linux/flutter_audio_desktop_plugin.cc
+++ b/linux/flutter_audio_desktop_plugin.cc
@@ -26,7 +26,8 @@ static void flutter_audio_desktop_plugin_handle_method_call(
 
   if (strcmp(method, "init") == 0)
   {
-    int debug = fl_value_get_int(fl_method_call_get_args(method_call));
+    const int id = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("id")));
+    int debug = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("debug")));
 
     Audio::initPlayer(debug);
 
@@ -35,7 +36,8 @@ static void flutter_audio_desktop_plugin_handle_method_call(
 
   if (strcmp(method, "setDevice") == 0)
   {
-    int deviceIndex = fl_value_get_int(fl_method_call_get_args(method_call));
+    const int id = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("id")));
+    int deviceIndex = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("device_index")));
 
     Audio::setDevice(deviceIndex);
 
@@ -44,7 +46,8 @@ static void flutter_audio_desktop_plugin_handle_method_call(
 
   else if (strcmp(method, "load") == 0)
   {
-    const gchar *fileName = fl_value_get_string(fl_method_call_get_args(method_call));
+    const int id = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("id")));
+    const gchar *fileName = fl_value_get_string(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("file_location")));
 
     Audio::loadPlayer(fileName);
 
@@ -53,6 +56,7 @@ static void flutter_audio_desktop_plugin_handle_method_call(
 
   else if (strcmp(method, "loadWave") == 0)
   {
+    const int id = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("id")));
     const float amplitude = fl_value_get_float(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("amplitude")));
     const float frequency = fl_value_get_float(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("frequency")));
     const int waveType = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("wave_type")));
@@ -62,6 +66,8 @@ static void flutter_audio_desktop_plugin_handle_method_call(
 
   else if (strcmp(method, "play") == 0)
   {
+    const int id = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("id")));
+
     Audio::playPlayer();
 
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_null()));
@@ -69,6 +75,8 @@ static void flutter_audio_desktop_plugin_handle_method_call(
 
   else if (strcmp(method, "pause") == 0)
   {
+    const int id = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("id")));
+
     Audio::pausePlayer();
 
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_null()));
@@ -76,6 +84,8 @@ static void flutter_audio_desktop_plugin_handle_method_call(
 
   else if (strcmp(method, "stop") == 0)
   {
+    const int id = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("id")));
+
     Audio::stopPlayer();
 
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_null()));
@@ -83,6 +93,8 @@ static void flutter_audio_desktop_plugin_handle_method_call(
 
   else if (strcmp(method, "getDuration") == 0)
   {
+    const int id = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("id")));
+
     int playerDuration = Audio::getDuration();
 
     g_autoptr(FlValue) playerDurationResponse = fl_value_new_int(playerDuration);
@@ -92,6 +104,8 @@ static void flutter_audio_desktop_plugin_handle_method_call(
 
   else if (strcmp(method, "getPosition") == 0)
   {
+    const int id = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("id")));
+
     int playerPostion = Audio::getPosition();
 
     g_autoptr(FlValue) playerPostionResponse = fl_value_new_int(playerPostion);
@@ -101,32 +115,37 @@ static void flutter_audio_desktop_plugin_handle_method_call(
 
   else if (strcmp(method, "setPosition") == 0)
   {
+    const int id = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("id")));
+    // in Miliseconds
+    int duration = fl_value_get_float(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("duration")));
 
-    int timeMilliseconds = fl_value_get_int(fl_method_call_get_args(method_call));
-
-    Audio::setPosition(timeMilliseconds);
+    Audio::setPosition(duration);
 
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_null()));
   }
-    else if (strcmp(method, "setWaveAmplitude") == 0)
+  else if (strcmp(method, "setWaveAmplitude") == 0)
   {
-    float amplitude = fl_value_get_float(fl_method_call_get_args(method_call));
+    const int id = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("id")));
+
+    float amplitude = fl_value_get_float(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("amplitude")));
 
     Audio::setWaveAmplitude(amplitude);
 
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_null()));
   }
-    else if (strcmp(method, "setWaveFrequency") == 0)
+  else if (strcmp(method, "setWaveFrequency") == 0)
   {
-    float frequency = fl_value_get_float(fl_method_call_get_args(method_call));
+    const int id = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("id")));
 
+    float frequency = fl_value_get_float(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("frequency")));
     Audio::setWaveFrequency(frequency);
 
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_null()));
   }
-    else if (strcmp(method, "setWaveSampleRate") == 0)
+  else if (strcmp(method, "setWaveSampleRate") == 0)
   {
-    int sampleRate = fl_value_get_int(fl_method_call_get_args(method_call));
+    const int id = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("id")));
+    const int sampleRate = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("sampleRate")));
 
     Audio::setWaveSampleRate(sampleRate);
 
@@ -135,9 +154,10 @@ static void flutter_audio_desktop_plugin_handle_method_call(
 
   else if (strcmp(method, "setVolume") == 0)
   {
-    float volume = fl_value_get_float(fl_method_call_get_args(method_call));
+    const int id = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("id")));
+    float volume = fl_value_get_float(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("volume")));
 
-    Audio::setVolume(volume);
+    Audio::setVolume(id, volume);
 
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_null()));
   }

--- a/linux/flutter_audio_desktop_plugin.cc
+++ b/linux/flutter_audio_desktop_plugin.cc
@@ -29,7 +29,7 @@ static void flutter_audio_desktop_plugin_handle_method_call(
     const int id = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("id")));
     int debug = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("debug")));
 
-    Audio::initPlayer(debug);
+    Audio::initPlayer(id, debug);
 
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_null()));
   }
@@ -39,7 +39,7 @@ static void flutter_audio_desktop_plugin_handle_method_call(
     const int id = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("id")));
     int deviceIndex = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("device_index")));
 
-    Audio::setDevice(deviceIndex);
+    Audio::setDevice(id, deviceIndex);
 
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_null()));
   }
@@ -49,7 +49,7 @@ static void flutter_audio_desktop_plugin_handle_method_call(
     const int id = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("id")));
     const gchar *fileName = fl_value_get_string(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("file_location")));
 
-    Audio::loadPlayer(fileName);
+    Audio::loadPlayer(id, fileName);
 
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_null()));
   }
@@ -60,7 +60,7 @@ static void flutter_audio_desktop_plugin_handle_method_call(
     const float amplitude = fl_value_get_float(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("amplitude")));
     const float frequency = fl_value_get_float(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("frequency")));
     const int waveType = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("wave_type")));
-    Audio::loadWave(amplitude, frequency, waveType);
+    Audio::loadWave(id, amplitude, frequency, waveType);
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_null()));
   }
 
@@ -68,7 +68,7 @@ static void flutter_audio_desktop_plugin_handle_method_call(
   {
     const int id = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("id")));
 
-    Audio::playPlayer();
+    Audio::playPlayer(id);
 
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_null()));
   }
@@ -77,7 +77,7 @@ static void flutter_audio_desktop_plugin_handle_method_call(
   {
     const int id = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("id")));
 
-    Audio::pausePlayer();
+    Audio::pausePlayer(id);
 
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_null()));
   }
@@ -86,7 +86,7 @@ static void flutter_audio_desktop_plugin_handle_method_call(
   {
     const int id = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("id")));
 
-    Audio::stopPlayer();
+    Audio::stopPlayer(id);
 
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_null()));
   }
@@ -95,7 +95,7 @@ static void flutter_audio_desktop_plugin_handle_method_call(
   {
     const int id = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("id")));
 
-    int playerDuration = Audio::getDuration();
+    int playerDuration = Audio::getDuration(id);
 
     g_autoptr(FlValue) playerDurationResponse = fl_value_new_int(playerDuration);
 
@@ -106,7 +106,7 @@ static void flutter_audio_desktop_plugin_handle_method_call(
   {
     const int id = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("id")));
 
-    int playerPostion = Audio::getPosition();
+    int playerPostion = Audio::getPosition(id);
 
     g_autoptr(FlValue) playerPostionResponse = fl_value_new_int(playerPostion);
 
@@ -119,7 +119,7 @@ static void flutter_audio_desktop_plugin_handle_method_call(
     // in Miliseconds
     int duration = fl_value_get_float(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("duration")));
 
-    Audio::setPosition(duration);
+    Audio::setPosition(id, duration);
 
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_null()));
   }
@@ -129,7 +129,7 @@ static void flutter_audio_desktop_plugin_handle_method_call(
 
     float amplitude = fl_value_get_float(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("amplitude")));
 
-    Audio::setWaveAmplitude(amplitude);
+    Audio::setWaveAmplitude(id, amplitude);
 
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_null()));
   }
@@ -138,7 +138,7 @@ static void flutter_audio_desktop_plugin_handle_method_call(
     const int id = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("id")));
 
     float frequency = fl_value_get_float(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("frequency")));
-    Audio::setWaveFrequency(frequency);
+    Audio::setWaveFrequency(id, frequency);
 
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_null()));
   }
@@ -147,7 +147,7 @@ static void flutter_audio_desktop_plugin_handle_method_call(
     const int id = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("id")));
     const int sampleRate = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("sampleRate")));
 
-    Audio::setWaveSampleRate(sampleRate);
+    Audio::setWaveSampleRate(id, sampleRate);
 
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_null()));
   }

--- a/windows/flutter_audio_desktop_plugin.cpp
+++ b/windows/flutter_audio_desktop_plugin.cpp
@@ -297,11 +297,11 @@ namespace
       }
 
       // Map volume
-      int volume = 0;
+      double volume = 0;
       auto encodedVolume = arguments->find(flutter::EncodableValue("volume"));
       if (encodedVolume != arguments->end())
       {
-        volume = std::get<int>(encodedVolume->second);
+        volume = std::get<double>(encodedVolume->second);
       }
       Audio::setVolume(playerID, volume);
 

--- a/windows/flutter_audio_desktop_plugin.cpp
+++ b/windows/flutter_audio_desktop_plugin.cpp
@@ -59,134 +59,323 @@ namespace
 
     if (method_call.method_name() == "init")
     {
-      int debug = std::get<int>(*method_call.arguments());
+      const auto *arguments = std::get_if<flutter::EncodableMap>(method_call.arguments());
 
-      Audio::initPlayer(debug);
+      // Map Player ID
+      int playerID = 0;
+      auto encodedID = arguments->find(flutter::EncodableValue("id"));
+      if (encodedID != arguments->end())
+      {
+        playerID = std::get<int>(encodedID->second);
+      }
+      // Map debug status
+      int debug = false;
+      auto encodedDebug = arguments->find(flutter::EncodableValue("debug"));
+      if (encodedDebug != arguments->end())
+      {
+        debug = std::get<bool>(encodedDebug->second);
+      }
+
+      Audio::initPlayer(playerID, debug);
 
       result->Success(flutter::EncodableValue(nullptr));
     }
 
     else if (method_call.method_name() == "setDevice")
     {
-      int deviceIndex = std::get<int>(*method_call.arguments());
+      const auto *arguments = std::get_if<flutter::EncodableMap>(method_call.arguments());
 
-      Audio::setDevice(deviceIndex);
+      // Map Player ID
+      int playerID = 0;
+      auto encodedID = arguments->find(flutter::EncodableValue("id"));
+      if (encodedID != arguments->end())
+      {
+        playerID = std::get<int>(encodedID->second);
+      }
+
+      // Map Device Index
+      int deviceIndex = 0;
+      auto encodedDeviceIndex = arguments->find(flutter::EncodableValue("device_index"));
+      if (encodedDeviceIndex != arguments->end())
+      {
+        deviceIndex = std::get<int>(encodedDeviceIndex->second);
+      }
+      Audio::setDevice(playerID, deviceIndex);
 
       result->Success(flutter::EncodableValue(nullptr));
     }
 
     else if (method_call.method_name() == "load")
     {
-      std::string fileName = std::get<std::string>(*method_call.arguments());
 
-      Audio::loadPlayer(fileName.c_str());
+      const auto *arguments = std::get_if<flutter::EncodableMap>(method_call.arguments());
+
+      // Map Player ID
+      int playerID = 0;
+      auto encodedID = arguments->find(flutter::EncodableValue("id"));
+      if (encodedID != arguments->end())
+      {
+        playerID = std::get<int>(encodedID->second);
+      }
+
+      // Map File Location
+      std::string fileLocation = "";
+      auto encodedFileLocation = arguments->find(flutter::EncodableValue("file_location"));
+      if (encodedFileLocation != arguments->end())
+      {
+        fileLocation = std::get<std::string>(encodedFileLocation->second);
+      }
+      Audio::loadPlayer(playerID, fileLocation.c_str());
 
       result->Success(flutter::EncodableValue(nullptr));
     }
 
     else if (method_call.method_name() == "play")
     {
-      Audio::playPlayer();
+      const auto *arguments = std::get_if<flutter::EncodableMap>(method_call.arguments());
+
+      // Map Player ID
+      int playerID = 0;
+      auto encodedID = arguments->find(flutter::EncodableValue("id"));
+      if (encodedID != arguments->end())
+      {
+        playerID = std::get<int>(encodedID->second);
+      }
+      Audio::playPlayer(playerID);
 
       result->Success(flutter::EncodableValue(nullptr));
     }
     else if (method_call.method_name() == "loadWave")
     {
-      double amplitude = 0;
-      double frequency = 0;
-      int waveType = 0;
-
       const auto *arguments = std::get_if<flutter::EncodableMap>(method_call.arguments());
 
+      // Map Player ID
+      int playerID = 0;
+      auto encodedID = arguments->find(flutter::EncodableValue("id"));
+      if (encodedID != arguments->end())
+      {
+        playerID = std::get<int>(encodedID->second);
+      }
+
+      // Map amplitude
+      double amplitude = 0;
       auto encodedAmplitude = arguments->find(flutter::EncodableValue("amplitude"));
       if (encodedAmplitude != arguments->end())
       {
         amplitude = std::get<double>(encodedAmplitude->second);
       }
 
+      // Map frequency
+      double frequency = 0;
       auto encodedFrequency = arguments->find(flutter::EncodableValue("frequency"));
       if (encodedFrequency != arguments->end())
       {
         frequency = std::get<double>(encodedFrequency->second);
       }
 
+      // Map wave type
+      int waveType = 0;
       auto encodedWaveType = arguments->find(flutter::EncodableValue("wave_type"));
       if (encodedWaveType != arguments->end())
       {
         waveType = std::get<int>(encodedWaveType->second);
       }
 
-      Audio::loadWave(amplitude, frequency, waveType);
+      Audio::loadWave(playerID, amplitude, frequency, waveType);
 
       result->Success(flutter::EncodableValue(nullptr));
     }
 
     else if (method_call.method_name() == "pause")
     {
-      Audio::pausePlayer();
+      // Get args
+      const auto *arguments = std::get_if<flutter::EncodableMap>(method_call.arguments());
+
+      // Map Player ID
+      int playerID = 0;
+      auto encodedID = arguments->find(flutter::EncodableValue("id"));
+      if (encodedID != arguments->end())
+      {
+        playerID = std::get<int>(encodedID->second);
+      }
+
+      Audio::pausePlayer(playerID);
 
       result->Success(flutter::EncodableValue(nullptr));
     }
 
     else if (method_call.method_name() == "stop")
     {
-      Audio::stopPlayer();
+      // Get args
+      const auto *arguments = std::get_if<flutter::EncodableMap>(method_call.arguments());
+
+      // Map Player ID
+      int playerID = 0;
+      auto encodedID = arguments->find(flutter::EncodableValue("id"));
+      if (encodedID != arguments->end())
+      {
+        playerID = std::get<int>(encodedID->second);
+      }
+
+      Audio::stopPlayer(playerID);
 
       result->Success(flutter::EncodableValue(nullptr));
     }
 
     else if (method_call.method_name() == "getDuration")
     {
-      int playerDuration = Audio::getDuration();
+      // Get args
+      const auto *arguments = std::get_if<flutter::EncodableMap>(method_call.arguments());
+
+      // Map Player ID
+      int playerID = 0;
+      auto encodedID = arguments->find(flutter::EncodableValue("id"));
+      if (encodedID != arguments->end())
+      {
+        playerID = std::get<int>(encodedID->second);
+      }
+
+      int playerDuration = Audio::getDuration(playerID);
 
       result->Success(flutter::EncodableValue(playerDuration));
     }
 
     else if (method_call.method_name() == "getPosition")
     {
-      int playerPosition = Audio::getPosition();
+      // Get args
+      const auto *arguments = std::get_if<flutter::EncodableMap>(method_call.arguments());
+
+      // Map Player ID
+      int playerID = 0;
+      auto encodedID = arguments->find(flutter::EncodableValue("id"));
+      if (encodedID != arguments->end())
+      {
+        playerID = std::get<int>(encodedID->second);
+      }
+
+      int playerPosition = Audio::getPosition(playerID);
 
       result->Success(flutter::EncodableValue(playerPosition));
     }
 
     else if (method_call.method_name() == "setPosition")
     {
-      int timeMilliseconds = std::get<int>(*method_call.arguments());
+      // Get args
+      const auto *arguments = std::get_if<flutter::EncodableMap>(method_call.arguments());
 
-      Audio::setPosition(timeMilliseconds);
+      // Map Player ID
+      int playerID = 0;
+      auto encodedID = arguments->find(flutter::EncodableValue("id"));
+      if (encodedID != arguments->end())
+      {
+        playerID = std::get<int>(encodedID->second);
+      }
+
+      int duration = 0;
+      auto encodedDuration = arguments->find(flutter::EncodableValue("duration"));
+      if (encodedDuration != arguments->end())
+      {
+        duration = std::get<int>(encodedDuration->second);
+      }
+
+      Audio::setPosition(playerID, duration);
 
       result->Success(flutter::EncodableValue(nullptr));
     }
 
     else if (method_call.method_name() == "setVolume")
     {
-      double volume = std::get<double>(*method_call.arguments());
+      // Get args
+      const auto *arguments = std::get_if<flutter::EncodableMap>(method_call.arguments());
 
-      Audio::setVolume(volume);
+      // Map Player ID
+      int playerID = 0;
+      auto encodedID = arguments->find(flutter::EncodableValue("id"));
+      if (encodedID != arguments->end())
+      {
+        playerID = std::get<int>(encodedID->second);
+      }
+
+      // Map volume
+      int volume = 0;
+      auto encodedVolume = arguments->find(flutter::EncodableValue("volume"));
+      if (encodedVolume != arguments->end())
+      {
+        volume = std::get<int>(encodedVolume->second);
+      }
+      Audio::setVolume(playerID, volume);
 
       result->Success(flutter::EncodableValue(nullptr));
     }
     else if (method_call.method_name() == "setWaveAmplitude")
     {
-      double amplitude = std::get<double>(*method_call.arguments());
+      // Get args
+      const auto *arguments = std::get_if<flutter::EncodableMap>(method_call.arguments());
 
-      Audio::setWaveAmplitude(amplitude);
+      // Map Player ID
+      int playerID = 0;
+      auto encodedID = arguments->find(flutter::EncodableValue("id"));
+      if (encodedID != arguments->end())
+      {
+        playerID = std::get<int>(encodedID->second);
+      }
+
+      // Map volume
+      double amplitude = 0;
+      auto encodedAmplitude = arguments->find(flutter::EncodableValue("amplitude"));
+      if (encodedAmplitude != arguments->end())
+      {
+        amplitude = std::get<double>(encodedAmplitude->second);
+      }
+      Audio::setWaveAmplitude(playerID, amplitude);
 
       result->Success(flutter::EncodableValue(nullptr));
     }
     else if (method_call.method_name() == "setWaveFrequency")
     {
-      double frequency = std::get<double>(*method_call.arguments());
+      // Get args
+      const auto *arguments = std::get_if<flutter::EncodableMap>(method_call.arguments());
 
-      Audio::setWaveFrequency(frequency);
+      // Map Player ID
+      int playerID = 0;
+      auto encodedID = arguments->find(flutter::EncodableValue("id"));
+      if (encodedID != arguments->end())
+      {
+        playerID = std::get<int>(encodedID->second);
+      }
+
+      // Map volume
+      double frequency = 0;
+      auto encodedFrequency = arguments->find(flutter::EncodableValue("frequency"));
+      if (encodedFrequency != arguments->end())
+      {
+        frequency = std::get<double>(encodedFrequency->second);
+      }
+      Audio::setWaveFrequency(playerID, frequency);
 
       result->Success(flutter::EncodableValue(nullptr));
     }
     else if (method_call.method_name() == "setWaveSampleRate")
     {
-      int waveSampleRate = std::get<int>(*method_call.arguments());
+      // Get args
+      const auto *arguments = std::get_if<flutter::EncodableMap>(method_call.arguments());
 
-      Audio::setWaveSampleRate(waveSampleRate);
+      // Map Player ID
+      int playerID = 0;
+      auto encodedID = arguments->find(flutter::EncodableValue("id"));
+      if (encodedID != arguments->end())
+      {
+        playerID = std::get<int>(encodedID->second);
+      }
+
+      // Map volume
+      int waveSampleRate = 0;
+      auto encodedSampleRate = arguments->find(flutter::EncodableValue("sample_rate"));
+      if (encodedSampleRate != arguments->end())
+      {
+        waveSampleRate = std::get<int>(encodedSampleRate->second);
+      }
+      Audio::setWaveSampleRate(playerID, waveSampleRate);
 
       result->Success(flutter::EncodableValue(nullptr));
     }


### PR DESCRIPTION
This implements a vector in C++ to manage multiple instances of the audio player. I have tested with up to 1000 instances and I assume it could go to more. In dart, an ID only needs to be provided to the constructor. The audio player then provides this ID with every method channel call.

This PR also refactors method channel calls to de-serialize multiple arguments from a dart map. This pattern for gathering arguments should be followed on any additional APIs.