### PR TITLE
disable cout for linux and fix casts.

### DIFF
--- a/audioplayer/audio.cpp
+++ b/audioplayer/audio.cpp
@@ -7,9 +7,9 @@ namespace Audio
 
     AudioPlayerManager *audioPlayerManager = new AudioPlayerManager();
 
-    void initPlayer(int id, int debug)
+    void initPlayer(int id, bool debug)
     {
-        AudioPlayer *audioPlayer = new AudioPlayer(id, static_cast<bool>(debug));
+        AudioPlayer *audioPlayer = new AudioPlayer(id, debug);
         audioPlayerManager->players.insert(audioPlayerManager->players.end(), audioPlayer);
     }
 

--- a/audioplayer/audio.cpp
+++ b/audioplayer/audio.cpp
@@ -19,6 +19,12 @@ namespace Audio
         audioPlayer->setDevice(deviceIndex);
     }
 
+    int getDeviceCount()
+    {
+        AudioPlayer *audioPlayer = audioPlayerManager->players.at(0);
+        return audioPlayer->playbackDeviceCount;
+    }
+
     void loadPlayer(int id, const char *fileLocation)
     {
         auto audioPlayer = audioPlayerManager->players.at(id);

--- a/audioplayer/audioplayer.hpp
+++ b/audioplayer/audioplayer.hpp
@@ -62,7 +62,7 @@ public:
         }
         for (ma_uint32 index = 0; index < this->playbackDeviceCount; index += 1)
         {
-            std::cout << index << " - " << this->pPlaybackDeviceInfos[index].name << std::endl;
+            //std::cout << index << " - " << this->pPlaybackDeviceInfos[index].name << std::endl;
         }
     }
 
@@ -88,8 +88,8 @@ public:
         ma_device_init(NULL, &this->deviceConfig, &this->device);
         if (this->debug)
         {
-            std::cout << "Channel Count: " << this->decoder.outputChannels << std::endl;
-            std::cout << "Sample Rate  : " << this->decoder.outputSampleRate << std::endl;
+            //std::cout << "Channel Count: " << this->decoder.outputChannels << std::endl;
+            //std::cout << "Sample Rate  : " << this->decoder.outputSampleRate << std::endl;
         }
     }
 
@@ -108,8 +108,8 @@ public:
 
         if (this->debug)
         {
-            std::cout << "Channel Count: " << this->channelCount << std::endl;
-            std::cout << "Sample Rate  : " << this->sampleRate << std::endl;
+            //std::cout << "Channel Count: " << this->channelCount << std::endl;
+            //std::cout << "Sample Rate  : " << this->sampleRate << std::endl;
         }
     }
 };
@@ -129,7 +129,7 @@ public:
         this->deviceIndex = index;
         if (this->debug)
         {
-            std::cout << "Selected Device: " << this->deviceIndex << " - " << this->pPlaybackDeviceInfos[deviceIndex].name << std::endl;
+            //std::cout << "Selected Device: " << this->deviceIndex << " - " << this->pPlaybackDeviceInfos[deviceIndex].name << std::endl;
         }
     }
 
@@ -139,7 +139,7 @@ public:
         this->initDevice();
         if (this->debug)
         {
-            std::cout << "Loaded File: " << file << std::endl;
+            //std::cout << "Loaded File: " << file << std::endl;
         }
     }
 
@@ -149,8 +149,8 @@ public:
 
         if (this->debug)
         {
-            std::cout << std::boolalpha;
-            std::cout << "Started Playback. await = " << await << std::endl;
+            //std::cout << std::boolalpha;
+            //std::cout << "Started Playback. await = " << await << std::endl;
         }
         if (await)
             std::this_thread::sleep_for(std::chrono::milliseconds(this->getDuration()));
@@ -161,7 +161,7 @@ public:
         ma_device_stop(&this->device);
         if (this->debug)
         {
-            std::cout << "Paused Playback." << std::endl;
+            //std::cout << "Paused Playback." << std::endl;
         }
     }
 
@@ -171,7 +171,7 @@ public:
         ma_decoder_uninit(&this->decoder);
         if (this->debug)
         {
-            std::cout << "Stopped Playback." << std::endl;
+            //std::cout << "Stopped Playback." << std::endl;
         }
     }
 
@@ -179,7 +179,7 @@ public:
     {
         if (this->debug)
         {
-            std::cout << "Audio Duration: " << this->audioDurationMilliseconds << " ms" << std::endl;
+            //std::cout << "Audio Duration: " << this->audioDurationMilliseconds << " ms" << std::endl;
         }
         return this->audioDurationMilliseconds;
     }
@@ -190,7 +190,7 @@ public:
         ma_decoder_seek_to_pcm_frame(&decoder, timeFrames);
         if (this->debug)
         {
-            std::cout << "Set Position: " << timeMilliseconds << " ms" << std::endl;
+            //std::cout << "Set Position: " << timeMilliseconds << " ms" << std::endl;
         }
     }
 
@@ -201,7 +201,7 @@ public:
         int positionMilliseconds = ma_calculate_buffer_size_in_milliseconds_from_frames(static_cast<int>(positionFrames), this->sampleRate);
         if (this->debug)
         {
-            std::cout << "Current Position: " << positionMilliseconds << " ms" << std::endl;
+            //std::cout << "Current Position: " << positionMilliseconds << " ms" << std::endl;
         }
         return positionMilliseconds;
     }
@@ -211,7 +211,7 @@ public:
         ma_device_set_master_volume(&this->device, static_cast<float>(volume));
         if (this->debug)
         {
-            std::cout << "Set Volume: " << volume << std::endl;
+            //std::cout << "Set Volume: " << volume << std::endl;
         }
     }
 
@@ -266,7 +266,7 @@ public:
         ma_device_get_master_volume(&this->device, &volume);
         if (this->debug)
         {
-            std::cout << "Current Volume: " << volume << std::endl;
+            //std::cout << "Current Volume: " << volume << std::endl;
         }
         return volume;
     }

--- a/audioplayer/audioplayer.hpp
+++ b/audioplayer/audioplayer.hpp
@@ -29,6 +29,17 @@ void dataCallbackWave(ma_device *pDevice, void *pOutput, const void *pInput, ma_
     (void)pInput; /* Unused. */
 }
 
+struct AudioPlayerManager
+{
+    std::vector<AudioPlayer *> players;
+};
+
+struct AudioDevice
+{
+    int id;
+    std::string name;
+};
+
 class AudioPlayerInternal
 {
 public:
@@ -49,7 +60,7 @@ public:
     int id;
     int audioDurationMilliseconds;
 
-    void showDevices()
+    void findDevices()
     {
         ma_context context;
         if (ma_context_init(NULL, 0, NULL, &context) != MA_SUCCESS)
@@ -60,10 +71,45 @@ public:
         if (ma_context_get_devices(&context, &this->pPlaybackDeviceInfos, &this->playbackDeviceCount, &pCaptureDeviceInfos, &captureDeviceCount) != MA_SUCCESS)
         {
         }
-        for (ma_uint32 index = 0; index < this->playbackDeviceCount; index += 1)
+    }
+
+    void getDevices(AudioDevice* devices)
+    {
+        findDevices();
+        for (ma_uint32 index = 0; index < this->playbackDeviceCount; index++)
         {
-            std::cout << index << " - " << this->pPlaybackDeviceInfos[index].name << std::endl;
+            if (this->pPlaybackDeviceInfos[index].isDefault)
+            {
+                AudioDevice device;
+                device.name = "default";
+                device.id = index;
+                devices[this->playbackDeviceCount] = device;
+                //std::cout << index << " - " << this->pPlaybackDeviceInfos[index].name << "*" << std::endl;
+            }
+            else
+            {
+                AudioDevice device;
+                device.name = this->pPlaybackDeviceInfos[index].name;
+                device.id = index;
+                devices[index] = device;
+                //std::cout << index << " - " << this->pPlaybackDeviceInfos[index].name << std::endl;
+            }
         }
+    }
+
+    ma_device_info getDefaultDevice()
+    {
+        findDevices();
+        ma_device_info default = this->pPlaybackDeviceInfos[0];
+        for (ma_uint32 index = 0; index < this->playbackDeviceCount; index++)
+        {
+            // default becomes system default
+            if (this->pPlaybackDeviceInfos[index].isDefault)
+            {
+                default = this->pPlaybackDeviceInfos[index];
+            }
+        }
+        return default;
     }
 
     void loadFile(const char *file)
@@ -77,7 +123,7 @@ public:
 
     void initDevice()
     {
-        ma_device_id selectedDeviceId = this->pPlaybackDeviceInfos[this->deviceIndex].id;
+        ma_device_id selectedDeviceId = this->getDefaultDevice().id;
         this->deviceConfig = ma_device_config_init(ma_device_type_playback);
         this->deviceConfig.playback.pDeviceID = &selectedDeviceId;
         this->deviceConfig.playback.format = this->decoder.outputFormat;
@@ -96,7 +142,7 @@ public:
     void initDeviceWave()
     {
 
-        ma_device_id selectedDeviceId = this->pPlaybackDeviceInfos[this->deviceIndex].id;
+        ma_device_id selectedDeviceId = this->getDefaultDevice().id;
         this->deviceConfig = ma_device_config_init(ma_device_type_playback);
         this->deviceConfig.playback.pDeviceID = &selectedDeviceId;
         this->deviceConfig.playback.format = this->sampleFormat;
@@ -270,9 +316,4 @@ public:
         }
         return volume;
     }
-};
-
-struct AudioPlayerManager
-{
-    std::vector <AudioPlayer*> players;
 };

--- a/lib/flutter_audio_desktop.dart
+++ b/lib/flutter_audio_desktop.dart
@@ -28,11 +28,7 @@ class AudioPlayer {
   ///
   ///     AudioPlayer audioPlayer = new AudioPlayer(debug: true);
   AudioPlayer({this.debug = false, this.id = 0}) {
-    if (this.debug) {
-      _channel.invokeMethod('init', {'id': id, 'debug': true});
-    } else {
-      _channel.invokeMethod('init', {'id': id, 'debug': false});
-    }
+    _channel.invokeMethod('init', {'id': id, 'debug': debug});
   }
 
   /// ## Changing Playback Device

--- a/linux/flutter_audio_desktop_plugin.cc
+++ b/linux/flutter_audio_desktop_plugin.cc
@@ -26,8 +26,8 @@ static void flutter_audio_desktop_plugin_handle_method_call(
 
   if (strcmp(method, "init") == 0)
   {
-    const int id = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("id")));
-    int debug = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("debug")));
+    int id = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("id")));
+    bool debug = fl_value_get_bool(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("debug")));
 
     Audio::initPlayer(id, debug);
 
@@ -117,7 +117,7 @@ static void flutter_audio_desktop_plugin_handle_method_call(
   {
     const int id = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("id")));
     // in Miliseconds
-    int duration = fl_value_get_float(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("duration")));
+    int duration = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("duration")));
 
     Audio::setPosition(id, duration);
 
@@ -145,7 +145,7 @@ static void flutter_audio_desktop_plugin_handle_method_call(
   else if (strcmp(method, "setWaveSampleRate") == 0)
   {
     const int id = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("id")));
-    const int sampleRate = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("sampleRate")));
+    const int sampleRate = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("sample_rate")));
 
     Audio::setWaveSampleRate(id, sampleRate);
 

--- a/linux/flutter_audio_desktop_plugin.cc
+++ b/linux/flutter_audio_desktop_plugin.cc
@@ -112,7 +112,6 @@ static void flutter_audio_desktop_plugin_handle_method_call(
 
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(playerPostionResponse));
   }
-
   else if (strcmp(method, "setPosition") == 0)
   {
     const int id = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("id")));
@@ -122,6 +121,27 @@ static void flutter_audio_desktop_plugin_handle_method_call(
     Audio::setPosition(id, duration);
 
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_null()));
+  }
+  else if (strcmp(method, "getDevices") == 0)
+  {
+    int count = Audio::getDeviceCount();
+    AudioDevice devices[count + 1];
+    Audio::getDevices(&devices);
+
+    g_autoptr(FlValue) deviceInfo = fl_value_new_map();
+
+    for (int i = 1; i < count; i++)
+    {
+      fl_value_set_string_take(
+          deviceInfo, std::to_string(i),
+          fl_value_new_string(devices[i].name));
+    }
+
+    fl_value_set_string_take(
+        deviceInfo, "default",
+        fl_value_new_string(devices[count].id));
+
+    response = FL_METHOD_RESPONSE(fl_method_success_response_new(deviceInfo));
   }
   else if (strcmp(method, "setWaveAmplitude") == 0)
   {

--- a/windows/flutter_audio_desktop_plugin.cpp
+++ b/windows/flutter_audio_desktop_plugin.cpp
@@ -69,7 +69,7 @@ namespace
         playerID = std::get<int>(encodedID->second);
       }
       // Map debug status
-      int debug = false;
+      bool debug = false;
       auto encodedDebug = arguments->find(flutter::EncodableValue("debug"));
       if (encodedDebug != arguments->end())
       {


### PR DESCRIPTION
When testing for the upcoming set default changes I noticed std::cout throws casting issues on Linux. I commented these lines out for now and will work out a new method to send debug information across the method channel so that flutter can print versus relying on platforms to handle cout adequately.