### PR TITLE
Devices Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ var audioPlayer = new AudioPlayer(id: 0);
 // You can then change the device with setDevice,
 // and the ID included in the returned map.
 Map<String, dynamic> result = await audioPlayer.getDevices();
+// or if you don't need to refresh, access from
+audioPlayer.devices
 
 // Load audio file
 audioPlayer.load('/home/alexmercerind/music.mp3');

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ dependencies:
 // Note: You must provide new IDs to additional instances.
 var audioPlayer = new AudioPlayer(id: 0);
 
+// See a list of available system audio devices.
+// You can then change the device with setDevice,
+// and the ID included in the returned map.
+Map<String, dynamic> result = await audioPlayer.getDevices();
+
 // Load audio file
 audioPlayer.load('/home/alexmercerind/music.mp3');
 

--- a/audioplayer/audio.cpp
+++ b/audioplayer/audio.cpp
@@ -10,19 +10,26 @@ namespace Audio
     void initPlayer(int id, bool debug)
     {
         AudioPlayer *audioPlayer = new AudioPlayer(id, debug);
+        audioPlayer->findDevices();
         audioPlayerManager->players.insert(audioPlayerManager->players.end(), audioPlayer);
-    }
-
-    void setDevice(int id, int deviceIndex)
-    {
-        AudioPlayer *audioPlayer = audioPlayerManager->players.at(id);
-        audioPlayer->setDevice(deviceIndex);
     }
 
     int getDeviceCount()
     {
         AudioPlayer *audioPlayer = audioPlayerManager->players.at(0);
         return audioPlayer->playbackDeviceCount;
+    }
+
+    void getDevices(AudioDevice devices[])
+    {
+        AudioPlayer *audioPlayer = audioPlayerManager->players.at(0);
+        audioPlayer->getDevices(devices);
+    }
+
+    void setDevice(int id, int deviceIndex)
+    {
+        AudioPlayer *audioPlayer = audioPlayerManager->players.at(id);
+        audioPlayer->setDevice(deviceIndex);
     }
 
     void loadPlayer(int id, const char *fileLocation)

--- a/audioplayer/audioplayer.hpp
+++ b/audioplayer/audioplayer.hpp
@@ -249,7 +249,7 @@ public:
     {
         this->isPlaying = false;
         ma_device_stop(&this->device);
-        ma_decoder_uninit(&this->decoder);
+        //ma_decoder_uninit(&this->decoder);
         if (this->debug)
         {
             // TODO: Move debug output to message channel

--- a/audioplayer/audioplayer.hpp
+++ b/audioplayer/audioplayer.hpp
@@ -35,7 +35,6 @@ struct AudioDevice
     std::string name;
 };
 
-
 class AudioPlayerInternal
 {
 public:
@@ -69,7 +68,7 @@ public:
         {
         }
         this->deviceCount = 0;
-        for(int index = 0; index < this->playbackDeviceCount; index += 1)
+        for (ma_uint32 index = 0; index < this->playbackDeviceCount; index += 1)
         {
             this->deviceCount += 1;
         }
@@ -85,11 +84,9 @@ public:
             {
                 devices[count].name = this->pPlaybackDeviceInfos[index].name;
                 devices[count].id = index;
-               // std::cout << index << " - " << this->pPlaybackDeviceInfos[index].name << "*" <<"\n";;
             }
-                devices[index].name = this->pPlaybackDeviceInfos[index].name;
-                devices[index].id = index;
-               // std::cout << index << " - " << this->pPlaybackDeviceInfos[index].name << "\n";
+            devices[index].name = this->pPlaybackDeviceInfos[index].name;
+            devices[index].id = index;
         }
     }
 
@@ -130,6 +127,7 @@ public:
         ma_device_init(NULL, &this->deviceConfig, &this->device);
         if (this->debug)
         {
+            // TODO: Move debug output to message channel
             //std::cout << "Channel Count: " << this->decoder.outputChannels << std::endl;
             //std::cout << "Sample Rate  : " << this->decoder.outputSampleRate << std::endl;
         }
@@ -170,6 +168,7 @@ public:
         this->deviceIndex = index;
         if (this->debug)
         {
+            // TODO: Move debug output to message channel
             //std::cout << "Selected Device: " << this->deviceIndex << " - " << this->pPlaybackDeviceInfos[deviceIndex].name << std::endl;
         }
     }
@@ -180,6 +179,7 @@ public:
         this->initDevice();
         if (this->debug)
         {
+            // TODO: Move debug output to message channel
             //std::cout << "Loaded File: " << file << std::endl;
         }
     }
@@ -190,6 +190,7 @@ public:
 
         if (this->debug)
         {
+            // TODO: Move debug output to message channel
             //std::cout << std::boolalpha;
             //std::cout << "Started Playback. await = " << await << std::endl;
         }
@@ -202,6 +203,7 @@ public:
         ma_device_stop(&this->device);
         if (this->debug)
         {
+            // TODO: Move debug output to message channel
             //std::cout << "Paused Playback." << std::endl;
         }
     }
@@ -212,6 +214,7 @@ public:
         ma_decoder_uninit(&this->decoder);
         if (this->debug)
         {
+            // TODO: Move debug output to message channel
             //std::cout << "Stopped Playback." << std::endl;
         }
     }
@@ -220,6 +223,7 @@ public:
     {
         if (this->debug)
         {
+            // TODO: Move debug output to message channel
             //std::cout << "Audio Duration: " << this->audioDurationMilliseconds << " ms" << std::endl;
         }
         return this->audioDurationMilliseconds;
@@ -231,6 +235,7 @@ public:
         ma_decoder_seek_to_pcm_frame(&decoder, timeFrames);
         if (this->debug)
         {
+            // TODO: Move debug output to message channel
             //std::cout << "Set Position: " << timeMilliseconds << " ms" << std::endl;
         }
     }
@@ -242,9 +247,22 @@ public:
         int positionMilliseconds = ma_calculate_buffer_size_in_milliseconds_from_frames(static_cast<int>(positionFrames), this->sampleRate);
         if (this->debug)
         {
+            // TODO: Move debug output to message channel
             //std::cout << "Current Position: " << positionMilliseconds << " ms" << std::endl;
         }
         return positionMilliseconds;
+    }
+    
+    float getVolume()
+    {
+        float volume;
+        ma_device_get_master_volume(&this->device, &volume);
+        if (this->debug)
+        {
+            // TODO: Move debug output to message channel
+            //std::cout << "Current Volume: " << volume << std::endl;
+        }
+        return volume;
     }
 
     void setVolume(double volume)
@@ -252,6 +270,7 @@ public:
         ma_device_set_master_volume(&this->device, static_cast<float>(volume));
         if (this->debug)
         {
+            // TODO: Move debug output to message channel
             //std::cout << "Set Volume: " << volume << std::endl;
         }
     }
@@ -299,17 +318,6 @@ public:
                                     this->sampleRate, maWaveType, amplitude, frequency);
         ma_waveform_init(&this->sineWaveConfig, &this->sineWave);
         this->initDeviceWave();
-    }
-
-    float getVolume()
-    {
-        float volume;
-        ma_device_get_master_volume(&this->device, &volume);
-        if (this->debug)
-        {
-            //std::cout << "Current Volume: " << volume << std::endl;
-        }
-        return volume;
     }
 };
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -98,9 +98,6 @@ class PlayerState extends State<Player> {
                     ),
                     tooltip: 'Load Audio',
                     onPressed: () async {
-                      /// Setting playback device manually (if you have more than one playback device).
-                      audioPlayer.setDevice(deviceIndex: 2);
-
                       /// Loading an audio file into the player.
                       bool result =
                           await audioPlayer.load(this._textFieldValue);
@@ -192,6 +189,19 @@ class PlayerState extends State<Player> {
                           this.setState(() {
                             /// Changing player volume.
                             this.audioPlayer.setWaveSampleRate(value.toInt());
+                          });
+                        }),
+                    Slider(
+                        divisions: 4,
+                        value: audioPlayer.deviceIndex.toDouble(),
+                        min: 0,
+                        max: 3,
+                        onChanged: (value) {
+                          this.setState(() {
+                            /// Changing player volume.
+                            this
+                                .audioPlayer
+                                .setDevice(deviceIndex: value.toInt());
                           });
                         }),
                   ],

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -64,8 +64,6 @@ class PlayerState extends State<Player> {
                   size: 28,
                 ),
                 onPressed: () async {
-                  audioPlayer.setDevice(deviceIndex: 0);
-                  audioPlayer2.setDevice(deviceIndex: 0);
                   audioPlayer.loadWave(0.2, 400, 0);
                   audioPlayer2.loadWave(0.2, 700, 0);
                 },

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -134,6 +134,26 @@ class PlayerState extends State<Player> {
                             this.audioPlayer.setVolume(value);
                           });
                         }),
+                    Icon(
+                      Icons.device_hub,
+                      size: 36,
+                      color: Colors.blue,
+                    ),
+                    Slider(
+                        divisions: audioPlayer.devices.length > 0
+                            ? audioPlayer.devices.length
+                            : 1,
+                        value: audioPlayer.deviceIndex.toDouble(),
+                        min: 0,
+                        max: audioPlayer.devices.length.toDouble(),
+                        onChanged: (value) {
+                          this.setState(() {
+                            /// Changing player volume.
+                            this
+                                .audioPlayer
+                                .setDevice(deviceIndex: value.toInt());
+                          });
+                        }),
                   ],
                 )),
             Padding(
@@ -189,19 +209,6 @@ class PlayerState extends State<Player> {
                           this.setState(() {
                             /// Changing player volume.
                             this.audioPlayer.setWaveSampleRate(value.toInt());
-                          });
-                        }),
-                    Slider(
-                        divisions: 4,
-                        value: audioPlayer.deviceIndex.toDouble(),
-                        min: 0,
-                        max: 3,
-                        onChanged: (value) {
-                          this.setState(() {
-                            /// Changing player volume.
-                            this
-                                .audioPlayer
-                                .setDevice(deviceIndex: value.toInt());
                           });
                         }),
                   ],

--- a/lib/flutter_audio_desktop.dart
+++ b/lib/flutter_audio_desktop.dart
@@ -29,34 +29,36 @@ class AudioPlayer {
   ///     AudioPlayer audioPlayer = new AudioPlayer(debug: true);
   AudioPlayer({this.debug = false, this.id = 0}) {
     _channel.invokeMethod('init', {'id': id, 'debug': debug});
-    printDevices();
+    if (debug) {
+      _printDevices();
+    }
   }
 
-  void printDevices() async {
+  void _printDevices() async {
     var devices = await getDevices();
     print(devices);
   }
 
   /// ## Get Audio Devices
   ///
-  ///     Map<String,dynamic> audioDevices= await audioPlayer.getDevices();
+  ///     Map<String,dynamic> audioDevices = await audioPlayer.getDevices();
+  ///
+  /// The key of the default device can be found at the "default" key
   ///
   ///  Results in `Future<Duration>`.
   Future<dynamic> getDevices() async {
     return await _channel.invokeMethod('getDevices');
   }
 
-  /// ## Changing Playback Device
+  /// ## Change Playback Device
   ///
-  ///     await audioPlayer.setDevice(deviceIndex: 0);
-  ///
-  /// NOTE: This method must be called before [load] method.
+  ///     await audioPlayer.setDevice(deviceIndex: await GetDevices()['default']);
   ///
   /// This method might be useful, if your device has more than one available playback devices.
   void setDevice({int deviceIndex = 0}) => _channel
       .invokeMethod('setDevice', {'id': id, 'device_index': deviceIndex});
 
-  /// ## Loading Audio File
+  /// ## Load Audio File
   ///
   ///     await audioPlayer.load('/home/alexmercerind/music.mp3');
   ///
@@ -91,7 +93,7 @@ class AudioPlayer {
     }
   }
 
-  /// ## Playing Loaded Audio File
+  /// ## Play Loaded Audio File
   ///
   ///     await audioPlayer.play();
   ///
@@ -114,7 +116,7 @@ class AudioPlayer {
     return success;
   }
 
-  /// ## Loading Waves
+  /// ## Load Waveform Synthesizer
   ///
   ///  Results in `Future<true>`, if the wave is successfully loaded.
   ///
@@ -154,7 +156,7 @@ class AudioPlayer {
     return success;
   }
 
-  /// ## Pausing Loaded Audio File
+  /// ## Pause Audio
   ///
   ///     await audioPlayer.pause();
   ///
@@ -175,7 +177,7 @@ class AudioPlayer {
     }
   }
 
-  /// ## Unloading Audio File
+  /// ## Unload Audio File
   ///
   ///     await audioPlayer.pause();
   ///
@@ -201,7 +203,7 @@ class AudioPlayer {
     }
   }
 
-  /// ## Getting Audio File Duration
+  /// ## Gets Audio File Duration
   ///
   ///     Duration audioDuration = await audioPlayer.getDuration();
   ///
@@ -217,7 +219,7 @@ class AudioPlayer {
     }
   }
 
-  /// ## Getting Audio Playback Position
+  /// ## Gets Audio Playback Position
   ///
   ///     Duration audioPosition = await audioPlayer.getPosition();
   ///
@@ -237,7 +239,7 @@ class AudioPlayer {
     }
   }
 
-  /// ## Setting Audio Playback Position
+  /// ## Sets Audio Playback Position
   ///
   ///     await audioPlayer.setPosition(Duration(seconds: 18));
   ///
@@ -254,7 +256,7 @@ class AudioPlayer {
     }
   }
 
-  /// ## Setting Audio Playback Volume
+  /// ## Sets Audio Playback Volume
   ///
   ///     audioPlayer.setVolume(0.25);
   ///
@@ -266,18 +268,39 @@ class AudioPlayer {
     this.volume = volume;
   }
 
+  /// ## Sets Audio Wave Amplitude
+  ///
+  ///     audioPlayer.setWaveAmplitude(0.25);
+  ///
+  /// You can access the amplitude of the wave anytime later on.
+  ///
+  ///     double currentAmplitude = audioPlayer.waveAmplitude;
   void setWaveAmplitude(double amplitude) {
     _channel
         .invokeMethod('setWaveAmplitude', {'id': id, 'amplitude': amplitude});
     this.waveAmplitude = amplitude;
   }
 
+  /// ## Sets Audio Wave Frequency
+  ///
+  ///     audioPlayer.setWaveFrequency(528);
+  ///
+  /// You can access the frequency of the wave anytime later on.
+  ///
+  ///     double currentFrequency = audioPlayer.waveFrequency;
   void setWaveFrequency(double frequency) {
     _channel
         .invokeMethod('setWaveFrequency', {'id': id, 'frequency': frequency});
     this.waveFrequency = frequency;
   }
 
+  /// ## Sets Audio Wave Sample Rate
+  ///
+  ///     audioPlayer.setWaveSampleRate(44800);
+  ///
+  /// You can access the sample rate of the wave anytime later on.
+  ///
+  ///     double currentSampleRate = audioPlayer.waveSampleRate;
   void setWaveSampleRate(int sampleRate) {
     _channel.invokeMethod(
         'setWaveSampleRate', {'id': id, 'sample_rate': sampleRate});

--- a/lib/flutter_audio_desktop.dart
+++ b/lib/flutter_audio_desktop.dart
@@ -20,6 +20,7 @@ class AudioPlayer {
   double waveFrequency = 440;
   int waveSampleRate = 44800;
   List<bool> _playerState = [false, false, false, true];
+  Map<dynamic, dynamic> devices = new Map<dynamic, dynamic>();
 
   /// ## Starting Audio Service
   ///
@@ -31,15 +32,10 @@ class AudioPlayer {
   AudioPlayer({this.debug = false, this.id = 0}) {
     _channel.invokeMethod('init', {'id': id, 'debug': debug});
     if (debug) {
-      _printDevices();
+      getDevices(printDebug: true);
+    } else {
+      getDevices(printDebug: false);
     }
-  }
-
-  void _printDevices() async {
-    var devices = await getDevices();
-    deviceIndex = devices['default'];
-    print("Default: " + deviceIndex.toString());
-    print(devices);
   }
 
   /// ## Get Audio Devices
@@ -49,8 +45,14 @@ class AudioPlayer {
   /// The key of the default device can be found at the "default" key
   ///
   ///  Results in `Future<Duration>`.
-  Future<dynamic> getDevices() async {
-    return await _channel.invokeMethod('getDevices');
+  Future<dynamic> getDevices({bool printDebug = false}) async {
+    devices = await _channel.invokeMethod('getDevices');
+    deviceIndex = devices['default'];
+    if (printDebug) {
+      print("Default: " + deviceIndex.toString());
+      print(devices);
+    }
+    return devices;
   }
 
   /// ## Change Playback Device

--- a/lib/flutter_audio_desktop.dart
+++ b/lib/flutter_audio_desktop.dart
@@ -29,6 +29,21 @@ class AudioPlayer {
   ///     AudioPlayer audioPlayer = new AudioPlayer(debug: true);
   AudioPlayer({this.debug = false, this.id = 0}) {
     _channel.invokeMethod('init', {'id': id, 'debug': debug});
+    printDevices();
+  }
+
+  void printDevices() async {
+    var devices = await getDevices();
+    print(devices);
+  }
+
+  /// ## Get Audio Devices
+  ///
+  ///     Map<String,dynamic> audioDevices= await audioPlayer.getDevices();
+  ///
+  ///  Results in `Future<Duration>`.
+  Future<dynamic> getDevices() async {
+    return await _channel.invokeMethod('getDevices');
   }
 
   /// ## Changing Playback Device

--- a/lib/flutter_audio_desktop.dart
+++ b/lib/flutter_audio_desktop.dart
@@ -10,6 +10,7 @@ final MethodChannel _channel = MethodChannel('flutter_audio_desktop');
 class AudioPlayer {
   final int id;
   final bool debug;
+  int deviceIndex = 0;
   bool isLoaded = false;
   bool isPlaying = false;
   bool isPaused = false;
@@ -36,6 +37,8 @@ class AudioPlayer {
 
   void _printDevices() async {
     var devices = await getDevices();
+    deviceIndex = devices['default'];
+    print("Default: " + deviceIndex.toString());
     print(devices);
   }
 
@@ -55,8 +58,10 @@ class AudioPlayer {
   ///     await audioPlayer.setDevice(deviceIndex: await GetDevices()['default']);
   ///
   /// This method might be useful, if your device has more than one available playback devices.
-  void setDevice({int deviceIndex = 0}) => _channel
-      .invokeMethod('setDevice', {'id': id, 'device_index': deviceIndex});
+  void setDevice({int deviceIndex = 0}) {
+    this.deviceIndex = deviceIndex;
+    _channel.invokeMethod('setDevice', {'id': id, 'device_index': deviceIndex});
+  }
 
   /// ## Load Audio File
   ///

--- a/linux/flutter_audio_desktop_plugin.cc
+++ b/linux/flutter_audio_desktop_plugin.cc
@@ -123,13 +123,15 @@ static void flutter_audio_desktop_plugin_handle_method_call(
   }
   else if (strcmp(method, "getDevices") == 0)
   {
+    // Get count, new array, fill array
     int count = Audio::getDeviceCount();
-
     AudioDevice* devices = new AudioDevice[count + 1];
     Audio::getDevices(devices);
 
+    // Map for flutter
     g_autoptr(FlValue) deviceInfo = fl_value_new_map();
 
+    // Fill Map
     for (int i = 0; i < count; i++)
     {
 	        const char *c = devices[i].name.c_str();        
@@ -137,7 +139,8 @@ static void flutter_audio_desktop_plugin_handle_method_call(
           deviceInfo, std::to_string(i).c_str(),
           fl_value_new_string(c));
     }
-
+    
+    // Set default
     fl_value_set_string_take(
         deviceInfo, "default",
         fl_value_new_int(devices[count].id));

--- a/linux/flutter_audio_desktop_plugin.cc
+++ b/linux/flutter_audio_desktop_plugin.cc
@@ -33,8 +33,7 @@ static void flutter_audio_desktop_plugin_handle_method_call(
 
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_null()));
   }
-
-  if (strcmp(method, "setDevice") == 0)
+  else if (strcmp(method, "setDevice") == 0)
   {
     const int id = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("id")));
     int deviceIndex = fl_value_get_int(fl_value_lookup(fl_method_call_get_args(method_call), fl_value_new_string("device_index")));
@@ -125,21 +124,23 @@ static void flutter_audio_desktop_plugin_handle_method_call(
   else if (strcmp(method, "getDevices") == 0)
   {
     int count = Audio::getDeviceCount();
-    AudioDevice devices[count + 1];
-    Audio::getDevices(&devices);
+
+    AudioDevice* devices = new AudioDevice[count + 1];
+    Audio::getDevices(devices);
 
     g_autoptr(FlValue) deviceInfo = fl_value_new_map();
 
-    for (int i = 1; i < count; i++)
+    for (int i = 0; i < count; i++)
     {
-      fl_value_set_string_take(
-          deviceInfo, std::to_string(i),
-          fl_value_new_string(devices[i].name));
+	        const char *c = devices[i].name.c_str();        
+          fl_value_set_string_take(
+          deviceInfo, std::to_string(i).c_str(),
+          fl_value_new_string(c));
     }
 
     fl_value_set_string_take(
         deviceInfo, "default",
-        fl_value_new_string(devices[count].id));
+        fl_value_new_int(devices[count].id));
 
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(deviceInfo));
   }

--- a/windows/flutter_audio_desktop_plugin.cpp
+++ b/windows/flutter_audio_desktop_plugin.cpp
@@ -80,7 +80,24 @@ namespace
 
       result->Success(flutter::EncodableValue(nullptr));
     }
+    else if (method_call.method_name() == "getDevices")
+    {
+      // Map Device Index
+      int count = Audio::getDeviceCount();
+      AudioDevice *devices = new AudioDevice[count + 1];
+      Audio::getDevices(devices);
 
+      auto deviceInfo = flutter::EncodableMap();
+      for (int i = 0; i < count; i++)
+      {
+        deviceInfo.insert_or_assign(flutter::EncodableValue(std::to_string(i).c_str()),
+                                    flutter::EncodableValue(devices[i].name.c_str()));
+      }
+      deviceInfo.insert_or_assign(flutter::EncodableValue("default"),
+                                  flutter::EncodableValue(devices[count].id));
+
+      result->Success(flutter::EncodableValue(deviceInfo));
+    }
     else if (method_call.method_name() == "setDevice")
     {
       const auto *arguments = std::get_if<flutter::EncodableMap>(method_call.arguments());


### PR DESCRIPTION
This PR refactors devices to allow users to retrieve the names of devices in dart for display in selection menus.

Adds:

```dart
// See a list of available system audio devices.
// You can then change the device with setDevice,
// and the ID included in the returned map.
Map<String, dynamic> result = await audioPlayer.getDevices();
// or if you don't need to refresh, access from
// audioPlayer.devices
```

The system default will automatically be the selected device on init.
setDevice can now be used to change devices dynamically.
On all AudioPlayers there is a public map devices that is auto-populated on init. Calling getDevices() will refresh this list if new devices are added/deleted from the system.